### PR TITLE
Fix a few bugs

### DIFF
--- a/discovery/kubernetes/endpoints_test.go
+++ b/discovery/kubernetes/endpoints_test.go
@@ -376,7 +376,7 @@ func TestEndpointsDiscoveryUpdate(t *testing.T) {
 }
 
 func TestEndpointsDiscoveryEmptySubsets(t *testing.T) {
-	n, _, eps, _ := makeTestEndpointsDiscovery()
+	n, _, eps, _, _ := makeTestEndpointsDiscovery()
 	eps.GetStore().Add(makeEndpoints())
 
 	k8sDiscoveryTest{

--- a/discovery/kubernetes/ingress.go
+++ b/discovery/kubernetes/ingress.go
@@ -66,6 +66,8 @@ func (e *Ingress) enqueue(obj interface{}) {
 
 // Run implements the Discoverer interface.
 func (s *Ingress) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
+	defer s.queue.ShutDown()
+
 	if !cache.WaitForCacheSync(ctx.Done(), s.informer.HasSynced) {
 		level.Error(s.logger).Log("msg", "ingress informer unable to sync cache")
 		return
@@ -82,39 +84,37 @@ func (s *Ingress) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	workFunc := func() bool {
 		keyObj, quit := s.queue.Get()
 		if quit {
-			return true
+			return false
 		}
 		defer s.queue.Done(keyObj)
 		key := keyObj.(string)
 
 		namespace, name, err := cache.SplitMetaNamespaceKey(key)
 		if err != nil {
-			return false
+			return true
 		}
 
 		o, exists, err := s.store.GetByKey(key)
 		if err != nil {
-			return false
+			return true
 		}
 		if !exists {
 			send(&targetgroup.Group{Source: ingressSourceFromNamespaceAndName(namespace, name)})
-			return false
+			return true
 		}
 		eps, err := convertToIngress(o)
 		if err != nil {
 			level.Error(s.logger).Log("msg", "converting to Ingress object failed", "err", err)
-			return false
+			return true
 		}
 		send(s.buildIngress(eps))
-		return false
+		return true
 	}
 
-	for {
-		quit := workFunc()
-		if quit {
-			return
+	go func() {
+		for workFunc() {
 		}
-	}
+	}()
 
 	// Block until the target provider is explicitly canceled.
 	<-ctx.Done()

--- a/discovery/kubernetes/kubernetes_shared.go
+++ b/discovery/kubernetes/kubernetes_shared.go
@@ -39,7 +39,7 @@ type kubernetesShared struct {
 }
 
 func newKubernetesShared(client kubernetes.Interface, stopCh <-chan struct{}) *kubernetesShared {
-	return &kubernetesShared{client: client, count: 1, informers: map[string]cache.SharedInformer{}}
+	return &kubernetesShared{client: client, count: 1, stopCh: stopCh, informers: map[string]cache.SharedInformer{}}
 }
 
 func (c *kubernetesShared) MustGetSharedInformer(resource string, namespace string) cache.SharedInformer {


### PR DESCRIPTION
- KubernetesSharedCache should pass stopCh to KubernetesShared.
- Each controller should run working logic in a separate logic, and
  wait for stop signal. After controller is stopped, do cleanup (close
  queue, etc).